### PR TITLE
fix: ensure close button also triggers cleanup

### DIFF
--- a/src/LiquidAuthClient.ts
+++ b/src/LiquidAuthClient.ts
@@ -255,9 +255,12 @@ export class LiquidAuthClient {
         document.body.appendChild(this.modalElement);
   
         const closeButton = this.modalElement.querySelector('.close-button') as HTMLElement;
-        const hideListener = () => this.hideModal();
-        closeButton.addEventListener('click', hideListener);
-        this.eventListeners.push({ element: closeButton, type: 'click', listener: hideListener });
+        const closeListener = () => {
+          this.hideModal();
+          this.cleanUp();
+        };
+        closeButton.addEventListener('click', closeListener);
+        this.eventListeners.push({ element: closeButton, type: 'click', listener: closeListener });
   
         const startButton = this.modalElement.querySelector('#start') as HTMLButtonElement;
         const startListener = () => this.handleOfferClient();


### PR DESCRIPTION
Currently closing the button only hides the modal, it doesn't trigger the cleanUp() which would go ahead with the kind of closing and deletion of elements that we would expect when pressing the close button.

This creates a bug in use-wallet where if someone presses the X to close the modal, pressing the Connect button does nothing.

This PR 1) renames hideListener to closeListener, and 2) ensures cleanUp() is called.

Have confirmed that this works on my own fork.